### PR TITLE
Add stringify (from extension)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "get-params": "^0.1.2",
+    "jsan": "^3.1.5",
     "lodash": "^4.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import getParams from 'get-params';
+import jsan from 'jsan';
 
 export function generateId() {
   return Math.random().toString(36).substr(2);
@@ -76,3 +77,27 @@ export function evalMethod(action, obj) {
   return (new Function('args', `return this.${action.name}(args)`)).apply(obj, args);
 }
 /* eslint-enable */
+
+function tryCatchStringify(obj) {
+  try {
+    return JSON.stringify(obj);
+  } catch (err) {
+    /* eslint-disable no-console */
+    if (process.env.NODE_ENV !== 'production') console.log('Failed to stringify', err);
+    /* eslint-enable no-console */
+    return jsan.stringify(obj, null, null, { circular: '[CIRCULAR]' });
+  }
+}
+
+export function stringify(obj, serialize) {
+  if (typeof serialize === 'undefined') {
+    return tryCatchStringify(obj);
+  }
+  if (serialize === true) {
+    return jsan.stringify(obj, function(key, value) {
+      if (value && typeof value.toJS === 'function') return value.toJS();
+      return value;
+    }, null, true);
+  }
+  return jsan.stringify(obj, serialize.replacer, null, serialize.options);
+}


### PR DESCRIPTION
Just [take from extension](https://github.com/zalmoxisus/redux-devtools-extension/blob/39cf733ca63b41b367fa4bc0546a2ee33a388a9c/src/app/api/index.js#L6-L28), for support `serializeAction` and `serializeState` options on remote-redux-devtools & react-native-debugger.