### PR TITLE
Add importState (from extension)

### DIFF
--- a/src/importState.js
+++ b/src/importState.js
@@ -1,0 +1,31 @@
+import mapValues from 'lodash/mapValues';
+import { parse } from 'jsan';
+
+export default function importState(state, { deserializeState, deserializeAction }) {
+  if (!state) return undefined;
+  let preloadedState;
+  let nextLiftedState = parse(state);
+  if (nextLiftedState.payload) {
+    if (nextLiftedState.preloadedState) preloadedState = parse(nextLiftedState.preloadedState);
+    nextLiftedState = parse(nextLiftedState.payload);
+  }
+  if (deserializeState) {
+    if (typeof nextLiftedState.computedStates !== 'undefined') {
+      nextLiftedState.computedStates = nextLiftedState.computedStates.map(computedState => ({
+        ...computedState,
+        state: deserializeState(computedState.state)
+      }));
+    }
+    if (typeof nextLiftedState.committedState !== 'undefined') {
+      nextLiftedState.committedState = deserializeState(nextLiftedState.committedState);
+    }
+  }
+  if (deserializeAction) {
+    nextLiftedState.actionsById = mapValues(nextLiftedState.actionsById, liftedAction => ({
+      ...liftedAction,
+      action: deserializeAction(liftedAction.action)
+    }));
+  }
+
+  return { nextLiftedState, preloadedState };
+}


### PR DESCRIPTION
1. Just take from [extension](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/src/app/api/importState.js), for support `deserializeAction` and `deserializeState` on remote-redux-devtools and react-native-debugger.
2. Use `lodash.mapvalues` instead of `lodash` (It can reduce time of installation)