### PR TITLE
Add getLocalFilter (from extension)

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -24,6 +24,16 @@ function filterStates(computedStates, statesFilter) {
   ));
 }
 
+export function getLocalFilter(config) {
+  if (config.actionsBlacklist || config.actionsWhitelist) {
+    return {
+      whitelist: config.actionsWhitelist && config.actionsWhitelist.join('|'),
+      blacklist: config.actionsBlacklist && config.actionsBlacklist.join('|')
+    };
+  }
+  return undefined;
+}
+
 function getDevToolsOptions() {
   return typeof window !== 'undefined' && window.devToolsOptions || {};
 }


### PR DESCRIPTION
Just take from [extension](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/src/app/api/filters.js#L9). Also I see `remote-redux-devtools` and `react-native-debugger` haven't use it, so they may not be able to filter more than two actions.