### PR TITLE
Replace shortid to nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "get-params": "^0.1.2",
     "jsan": "^3.1.5",
     "lodash": "^4.0.0",
-    "remotedev-serialize": "^0.1.0",
-    "shortid": "^2.2.6"
+    "nanoid": "^1.0.1",
+    "remotedev-serialize": "^0.1.0"
   },
   "pre-commit": [
     "lint"

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import getParams from 'get-params';
 import jsan from 'jsan';
-import shortid from 'shortid';
+import nanoid from 'nanoid';
 import seralizeImmutable from 'remotedev-serialize/immutable/serialize';
 
 export function generateId(id) {
-  return id || shortid.generate();
+  return id || nanoid(7);
 }
 
 function flatTree(obj, namespace = '') {


### PR DESCRIPTION
What do you think of replacing `shortid` to [`nanoid`](https://github.com/ai/nanoid) (without big changes for users). Benefits:

1. `shortid` is not maintained anymore (and issue tracker has many important issues). I tried to took maintenance, but found that I can’t fix `shortid` with keeping API.
2. `shortid` has problem with random generator ([issue](https://github.com/dylang/shortid/issues/70)) and ID uniformity ([issue](https://github.com/dylang/shortid/issues/85)). `nanoid` use hardware random generator and has special uniformity tests ([docs](https://github.com/ai/nanoid#security)).
3. `nanoid` is just [179 bytes](https://github.com/ai/nanoid/blob/master/package.json#L64-L67). `shortid` is 2 times bigger (about 0.5 KB).
4. `nanoid` is [10x times faster](https://github.com/ai/nanoid#benchmark) than `shortid`.

@zalmoxisus what do you think?